### PR TITLE
添加802.1X认证模式

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,11 @@ ifeq ($(debug), y)
 endif
 
 ifeq ($(win32), y)
-	CFLAGS += -std=gnu99 -Werror -lws2_32
+	CFLAGS += -std=gnu99 -Werror -DWINDOWS -DHAVE_REMOTE -I wpcap/include \
+			  -L wpcap/lib -lwpcap -lpacket -l-lws2_32
 	TARGET = dogcom-MinGW
+else
+	CFLAGS += -std=gnu99 -Werror -DLINUX
 endif
 
 ifeq ($(force_encrypt), y)

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Options:
         --mode <dhcp/pppoe>, -m <dhcp/pppoe>  set your dogcom mode
         --conf <FILEPATH>, -c <FILEPATH>      import configuration file
         --log <LOGPATH>, -l <LOGPATH>         specify log file
+        --802.1x, -8                          enable 802.1x
         --daemon, -d                          set daemon flag
         --verbose, -v                         set verbose flag
         --help, -h                            display this help

--- a/common.c
+++ b/common.c
@@ -1,0 +1,325 @@
+/*
+ * 一些通用的代码
+ */
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <ctype.h>
+#include <errno.h>
+#include <time.h>
+#include "common.h"
+
+#ifdef LINUX
+# include <unistd.h>
+# include <arpa/inet.h>
+# include <net/ethernet.h>
+# include <sys/select.h>
+# include <net/if_arp.h>
+# include <net/if.h>
+# include <sys/ioctl.h>
+# include <netpacket/packet.h>
+# define PATH_SEP   '/'
+#elif defined(WINDOWS)
+# include <windows.h>
+# include <pcap.h>
+# define PATH_SEP   '\\'
+#endif
+
+
+extern int getexedir(char *exedir)
+{
+#ifdef LINUX
+    int cnt = readlink("/proc/self/exe", exedir, EXE_PATH_MAX);
+#elif defined(WINDOWS)
+    int cnt = GetModuleFileName(NULL, exedir, EXE_PATH_MAX);
+#endif
+    if (cnt < 0 || cnt >= EXE_PATH_MAX)
+        return -1;
+    _D("exedir: %s\n", exedir);
+    char *end = strrchr(exedir, PATH_SEP);
+    if (!end) return -1;
+    *(end+1) = '\0';
+    _D("exedir: %s\n", exedir);
+    return 0;
+}
+
+extern int mac_equal(uchar const *mac1, uchar const *mac2)
+{
+	int i;
+	for (i = 0; i < ETH_ALEN; ++i) {
+		if (mac1[i] != mac2[i])
+			return 0;
+	}
+
+	return 1;
+}
+extern int ip_equal(int type, void const *ip1, void const *ip2)
+{
+	uchar const *p1 = (uchar const*)ip1;
+	uchar const *p2 = (uchar const*)ip2;
+	int len = 4;
+	if (AF_INET6 == type) {
+		len = 16;
+	}
+	int i;
+	for (i = 0; i < len; ++i) {
+		if (p1[i] != p2[i])
+			return 0;
+	}
+	return 1;
+}
+
+static int is_filter(char const *ifname)
+{
+	/* 过滤掉无线，虚拟机接口等 */
+	char const *filter[] = {
+		/* windows */
+		"Wireless", "Microsoft",
+		"Virtual",
+		/* linux */
+		"lo", "wlan", "vboxnet",
+		"ifb", "gre", "teql",
+		"br", "imq", "ra",
+		"wds", "sit", "apcli",
+	};
+	unsigned int i;
+	for (i = 0; i < ARRAY_SIZE(filter); ++i) {
+		if (strstr(ifname, filter[i]))
+			return 1;
+	}
+	return 0;
+}
+#ifdef LINUX
+static char *get_ifname_from_buff(char *buff)
+{
+	char *s;
+	while (isspace(*buff))
+		++buff;
+	s = buff;
+	while (':' != *buff && '\0' != *buff)
+		++buff;
+	*buff = '\0';
+	return s;
+}
+#endif
+/*
+ * 获取所有网络接口
+ * ifnames 实际获取的接口
+ * cnt     两个作用，1：传入表示ifnames最多可以存储的接口个数
+ *                   2：返回表示实际获取了的接口个数
+ * 返回接口个数在cnt里
+ * @return: >=0  成功，实际获取的接口个数
+ *          -1 获取失败
+ *          -2 cnt过小
+ */
+extern int getall_ifs(iflist_t *ifs, int *cnt)
+{
+	int i = 0;
+	if (!ifs || *cnt <= 0) return -2;
+
+#ifdef LINUX    /* linux (unix osx?) */
+#define _PATH_PROCNET_DEV "/proc/net/dev"
+#define BUFF_LINE_MAX	(1024)
+	char buff[BUFF_LINE_MAX];
+	FILE *fd = fopen(_PATH_PROCNET_DEV, "r");
+	char *name;
+	if (NULL == fd) {
+		perror("fopen");
+		return -1;
+	}
+	/* _PATH_PROCNET_DEV文件格式如下,...表示后面我们不关心
+	 * Inter-|   Receive ...
+	 * face |bytes    packets ...
+	 * eth0: 147125283  119599 ...
+	 * wlan0:  229230    2635   ...
+	 * lo: 10285509   38254  ...
+	 */
+	/* 略过开始两行 */
+	fgets(buff, BUFF_LINE_MAX, fd);
+	fgets(buff, BUFF_LINE_MAX, fd);
+	while (NULL != fgets(buff, BUFF_LINE_MAX, fd)) {
+		name = get_ifname_from_buff(buff);
+		_D("%s\n", name);
+		/* 过滤无关网络接口 */
+		if (is_filter(name)) {
+			_D("filtered %s.\n", name);
+			continue;
+		}
+		strncpy(ifs[i].name, name, IFNAMSIZ);
+		_D("ifs[%d].name: %s\n", i, ifs[i].name);
+		++i;
+		if (i >= *cnt) {
+			fclose(fd);
+			return -2;
+		}
+	}
+	fclose(fd);
+
+#elif defined(WINDOWS)
+	pcap_if_t *alldevs;
+	char errbuf[PCAP_ERRBUF_SIZE];
+	if (-1 == pcap_findalldevs(&alldevs, errbuf)) {
+		_M("Get interfaces handler error: %s\n", errbuf);
+		return -1;
+	}
+	for (pcap_if_t *d = alldevs; d; d = d->next) {
+		if (is_filter(d->description)) {
+			_D("filtered %s.\n", d->description);
+			continue;
+		}
+		if (i >= *cnt) return -2;
+		strncpy(ifs[i].name, d->name, IFNAMSIZ);
+		strncpy(ifs[i].desc, d->description, IFDESCSIZ);
+		++i;
+	}
+	pcap_freealldevs(alldevs);
+#endif
+
+	*cnt = i;
+	return i;
+}
+
+extern char const *format_time(void)
+{
+	static char buff[FORMAT_TIME_MAX];
+	time_t rawtime;
+	struct tm *timeinfo;
+
+	time(&rawtime);
+	timeinfo = localtime(&rawtime);
+	if (NULL == timeinfo) return NULL;
+	strftime(buff, sizeof(buff), "%Y-%m-%d %H:%M:%S", timeinfo);
+
+	return buff;
+}
+extern int copy(char const *f1, char const *f2)
+{
+	if (NULL == f1 || NULL == f2) return -1;
+	FILE *src, *dst;
+	src = fopen(f1, "r");
+	dst = fopen(f2, "w");
+	if (NULL == src || NULL == dst) return -1;
+	char buff[1024];
+	int n;
+	while (0 < (n = fread(buff, 1, 1024, src)))
+		fwrite(buff, 1, n, dst);
+
+	fclose(src);
+	fclose(dst);
+
+	return 0;
+}
+/*
+ * 本地是否是小端序
+ * @return: !0: 是
+ *           0: 不是(大端序)
+ */
+static int islsb()
+{
+	static uint16 a = 0x0001;
+	return (int)(*(uchar*)&a);
+}
+static uint16 exorders(uint16 n)
+{
+	return ((n>>8)|(n<<8));
+}
+static uint32 exorderl(uint32 n)
+{
+	return (n>>24)|((n&0x00ff0000)>>8)|((n&0x0000ff00)<<8)|(n<<24);
+}
+extern uint16 htols(uint16 n)
+{
+	return islsb()?n:exorders(n);
+}
+extern uint16 htoms(uint16 n)
+{
+	return islsb()?exorders(n):n;
+}
+extern uint16 ltohs(uint16 n)
+{
+	return islsb()?n:exorders(n);
+}
+extern uint16 mtohs(uint16 n)
+{
+	return islsb()?exorders(n):n;
+}
+extern uint32 htoll(uint32 n)
+{
+	return islsb()?n:exorderl(n);
+}
+extern uint32 htoml(uint32 n)
+{
+	return islsb()?exorderl(n):n;
+}
+extern uint32 ltohl(uint32 n)
+{
+	return islsb()?n:exorderl(n);
+}
+extern uint32 mtohl(uint32 n)
+{
+	return islsb()?exorderl(n):n;
+}
+extern uchar const *format_mac(uchar const *macarr)
+{
+	static uchar formatmac[] =
+		"xx:xx:xx:xx:xx:xx";
+	if (NULL == macarr)
+		return NULL;
+	sprintf((char*)formatmac, "%.2X:%.2X:%.2X:%.2X:%.2X:%.2X",
+			macarr[0], macarr[1], macarr[2],
+			macarr[3], macarr[4], macarr[5]);
+	return formatmac;
+}
+/*
+ * 以16进制打印数据
+ */
+extern void format_data(uchar const *d, size_t len)
+{
+	int i;
+	for (i = 0; i < (long)len; ++i) {
+		if (i != 0 && i%16 == 0)
+			_M("\n");
+		_M("%02x ", d[i]);
+	}
+	_M("\n");
+}
+
+#ifdef LINUX
+/*
+ * 返回t1-t0的时间差
+ * 由于这里精度没必要达到ns，故返回相差微秒ms
+ * @return: 时间差，单位微秒(1s == 1000ms)
+ */
+extern long difftimespec(struct timespec t1, struct timespec t0)
+{
+	long d = t1.tv_sec-t0.tv_sec;
+	d *= 1000;
+	d += (t1.tv_nsec-t0.tv_nsec)/(long)(1e6);
+	return d;
+}
+
+/*
+ * 判断网络是否连通
+ * 最长延时3s，也就是说如果3s内没有检测到数据回应，那么认为网络不通
+ * TODO 使用icmp协议判断
+ * @return: !0: 连通
+ *           0: 没有连通
+ */
+extern int isnetok(char const *ifname)
+{
+	static char baidu[] = "baidu.com";
+	sleep(100);
+	return 1;
+}
+
+/*
+ * 休眠ms微秒
+ */
+extern void msleep(long ms)
+{
+	struct timeval tv;
+	tv.tv_sec = ms/1000;
+	tv.tv_usec = ms%1000*1000;
+	select(0, 0, 0, 0, &tv);
+}
+#endif /* LINUX */

--- a/common.h
+++ b/common.h
@@ -1,0 +1,161 @@
+#ifndef COMMON_H__
+#define COMMON_H__
+/*
+ * 通用的代码和定义
+ */
+typedef unsigned char uchar;	/* 一个字节 */
+typedef unsigned short uint16;	/* 两个字节 */
+typedef unsigned int uint32;	/* 四个字节 */
+
+/* 用户名和密码长度 */
+#define UNAME_LEN	(32)
+#define PWD_LEN		(32)
+
+#define FORMAT_TIME_MAX	(64)
+
+#ifdef LINUX
+# include <linux/limits.h>
+# include <netinet/if_ether.h>
+# include <arpa/inet.h>
+# include <net/if.h>
+# define EXE_PATH_MAX   (PATH_MAX+1)
+#elif defined(WINDOWS)
+# include <windows.h>
+# define ETH_ALEN	    (6)
+# define IF_NAMSIZE	    (64)
+# define MTU_MAX	    (65536)
+# define EXE_PATH_MAX   (MAX_PATH+1)
+# define IFDESCSIZ      (126)
+#endif
+
+typedef struct {
+    char name[IF_NAMESIZE]; /* linux下是eth0, windows采用的是注册表类似的(\Device\NPF_{xxxx-xxx-xx-xx-xxx}) */
+#ifdef WINDOWS
+    char desc[IFDESCSIZ]; /* windows下描述(AMD PCNET Family PCI Ethernet Adapter) */
+#endif
+}iflist_t;
+
+
+#undef ARRAY_SIZE
+#define ARRAY_SIZE(arr)	(sizeof(arr)/sizeof(arr[0]))
+
+#define MAX(x, y)	((x)>(y)?(x):(y))
+#define MIN(x, y)	((x)>(y)?(y):(x))
+
+#undef PRINT
+#ifdef GUI
+# include <glib.h>
+# define PRINT(...) g_print(__VA_ARGS__)
+#else
+# include <stdio.h>
+# define PRINT(...) fprintf(stderr, __VA_ARGS__)
+#endif
+
+#ifdef DEBUG
+# define _D(...) \
+    do { \
+        PRINT("%s:%s:%d:", format_time(), __FILE__, __LINE__); \
+        PRINT(__VA_ARGS__); \
+    } while(0)
+#else
+# define _D(...)    ((void)0)
+#endif
+
+#define _M(...)    PRINT(__VA_ARGS__);
+
+/*
+ * 获取程序所在的实际绝对路径的目录
+ * exedir: 返回目录，加上\0一起长度是EXE_PATH_MAX，
+ *         如果本上长度达到了EXE_PATH_MAX(不包括\0)，那么也会返回失败
+ * @return: 0: 成功
+ *         !0: 失败
+ */
+extern int getexedir(char *exedir);
+/*
+ * 比较两个mac是否相同
+ * @return: 0: 不同
+ *         !0: 相同
+ */
+extern int mac_equal(uchar const *mac1, uchar const *mac2);
+
+/*
+ * 判断两个ip是否相等
+ * type: AF_INET or AF_INET6, 分别对应ipv4,ipv6
+ * ip1, ip2: 比较的两个ip，同为struct in_addr或struct in6_addr的指针
+ * @return: 0: 不同
+ *         !0: 相同
+ */
+extern int ip_equal(int type, void const *ip1, void const *ip2);
+
+/*
+ * 获取所有网络接口
+ * ifnames 实际获取的接口
+ * cnt     两个作用，1：传入表示ifnames最多可以存储的接口个数
+ *                   2：返回表示实际获取了的接口个数
+ * 返回接口个数在cnt里
+ * @return: >=0  成功，实际获取的接口个数
+ *          -1 获取失败
+ *          -2 cnt过小
+ */
+extern int getall_ifs(iflist_t *ifs, int *cnt);
+/*
+ * 获取当前时间按照
+ * yyyy-MM-dd HH:mm:ss
+ * 格式返回
+ * NOTE 不要去修改返回结果，并且不是线程安全的
+ * @return: NULL: 失败
+ *         !NULL: 存储的结果
+ */
+extern char const *format_time(void);
+/*
+ * 简单的复制文件，暂时不进行细致错误检查
+ * NOTE 是绝对路径
+ * scr: 源文件
+ * dst: 目标文件
+ * @return: 0: 成功
+ *         -1: 失败
+ */
+extern int copy(char const *src, char const *dst);
+
+/*
+ * 字节序转换相关函数
+ * host to lsb/msb short/long (host->l/m)
+ * lsb/msb to host short/long (l/m->host)
+ */
+extern uint16 htols(uint16 n);
+extern uint16 htoms(uint16 n);
+extern uint16 ltohs(uint16 n);
+extern uint16 mtohs(uint16 n);
+
+extern uint32 htoll(uint32 n);
+extern uint32 htoml(uint32 n);
+extern uint32 ltohl(uint32 n);
+extern uint32 mtohl(uint32 n);
+
+extern uchar const *format_mac(uchar const *mac);
+
+/*
+ * 判断网络是否连通
+ * ifname: 接口名字
+ * @return: !0: 连通
+ *           0: 没有连通
+ */
+extern int isnetok(char const *ifname);
+/*
+ * 返回t1-t0的时间差
+ * 由于这里精度没必要达到ns，故返回相差微秒ms
+ * @return: 时间差，单位微秒(1s == 1000ms)
+ */
+extern long difftimespec(struct timespec t1, struct timespec t0);
+
+/*
+ * 休眠ms微秒
+ */
+extern void msleep(long ms);
+
+/*
+ * 以16进制打印数据
+ */
+extern void format_data(uchar const *d, size_t len);
+
+#endif

--- a/configparse.c
+++ b/configparse.c
@@ -6,6 +6,7 @@
 
 int verbose_flag = 0;
 int logging_flag = 0;
+int eapol_flag   = 0;
 char *log_path;
 char mode[10];
 struct config drcom_config;

--- a/configparse.h
+++ b/configparse.h
@@ -24,6 +24,7 @@ struct config {
 extern struct config drcom_config;
 extern int verbose_flag;
 extern int logging_flag;
+extern int eapol_flag;
 extern char *log_path;
 extern char mode[10];
 

--- a/eapol.c
+++ b/eapol.c
@@ -1,0 +1,510 @@
+#include "eapol.h"
+#include "common.h"
+#include "libs/md5.h"
+
+#include <netinet/if_ether.h>
+#include <net/if.h>
+#include <net/ethernet.h>
+#include <netpacket/packet.h>
+#include <arpa/inet.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/socket.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+
+#include <stdio.h>
+#include <string.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <time.h>
+#include <signal.h>
+
+#define BUFF_LEN	(512)
+
+static uchar client_mac[ETH_ALEN];
+
+static uchar sendbuff[BUFF_LEN];
+static uchar recvbuff[BUFF_LEN];
+static char ifname[IFNAMSIZ] = "eth0";
+static ethII_t *sendethii, *recvethii;
+static eapol_t *sendeapol, *recveapol;
+static eap_t *sendeap, *recveap;
+static eapbody_t *sendeapbody, *recveapbody;
+
+static char _uname[UNAME_LEN];
+static char _pwd[PWD_LEN];
+static int pwdlen;
+
+static int eap_keep_alive(int skfd, struct sockaddr const *skaddr);
+static int eap_md5_clg(int skfd, struct sockaddr const *skaddr);
+static int eap_res_identity(int skfd, struct sockaddr const *skaddr);
+static int eapol_init(int *skfd, struct sockaddr *skaddr);
+static int eapol_start(int skfd, struct sockaddr const *skaddr);
+static int eapol_logoff(int skfd, struct sockaddr const *skaddr);
+static int filte_req_identity(int skfd, struct sockaddr const *skaddr);
+static int filte_req_md5clg(int skfd, struct sockaddr const *skaddr);
+static int filte_success(int skfd, struct sockaddr const *skaddr);
+static int eap_daemon(int skfd, struct sockaddr const *skaddr);
+
+/*
+ * 初始化缓存区，生产套接字和地址接口信息
+ * skfd: 被初始化的socket
+ * skaddr: 被初始化地址接口信息
+ * @return: 0: 成功
+ *          -1: 初始化套接字失败
+ *          -2: 初始化地址信息失败
+ */
+static int eapol_init(int *skfd, struct sockaddr *skaddr)
+{
+	struct ifreq ifr;
+	struct sockaddr_ll *skllp = (struct sockaddr_ll*)skaddr;
+	sendethii = (ethII_t*)sendbuff;
+	sendeapol = (eapol_t*)((uchar*)sendethii+sizeof(ethII_t));
+	sendeap = (eap_t*)((uchar*)sendeapol+sizeof(eapol_t));
+	sendeapbody = (eapbody_t*)((uchar*)sendeap+sizeof(eap_t));
+	recvethii = (ethII_t*)recvbuff;
+	recveapol = (eapol_t*)((uchar*)recvethii+sizeof(ethII_t));
+	recveap = (eap_t*)((uchar*)recveapol+sizeof(eapol_t));
+	recveapbody = (eapbody_t*)((uchar*)recveap+sizeof(eap_t));
+
+	if (-1 == (*skfd = socket(PF_PACKET, SOCK_RAW, htons(ETH_P_ALL)))) {
+		perror("Socket");
+		return -1;
+	}
+	/* 先假定就是eth0接口 */
+	memset(skaddr, 0, sizeof(struct sockaddr_ll));
+	memset(&ifr, 0, sizeof(struct ifreq));
+	strncpy(ifr.ifr_name, ifname, IFNAMSIZ);
+	if (-1 == ioctl(*skfd, SIOCGIFINDEX, &ifr)) {
+		perror("Get index");
+		goto addr_err;
+	}
+	skllp->sll_ifindex = ifr.ifr_ifindex;
+    _D("%s's index: %d\n", ifname, skllp->sll_ifindex);
+	if (-1 == ioctl(*skfd, SIOCGIFHWADDR, &ifr)) {
+		perror("Get MAC");
+		goto addr_err;
+	}
+	memcpy(client_mac, ifr.ifr_hwaddr.sa_data, ETH_ALEN);
+	_D("%s's MAC: %02X-%02X-%02X-%02X-%02X-%02X\n", ifname,
+			client_mac[0],client_mac[1],client_mac[2],
+			client_mac[3],client_mac[4],client_mac[5]);
+	skllp->sll_family = PF_PACKET;	
+	/*skllp->sll_protocol = ETH_P_ARP;*/
+	/*skllp->sll_ifindex = ? 已给出 */
+	skllp->sll_hatype = ARPHRD_ETHER;
+	skllp->sll_pkttype = PACKET_HOST;
+	skllp->sll_halen = ETH_ALEN;
+	return 0;
+
+addr_err:
+	close(*skfd);
+	return -2;
+}
+
+/*
+ * 过滤得到eap-request-identity包
+ * @return: 0: 成功获取
+ *          -1: 超时
+ */
+static int filte_req_identity(int skfd, struct sockaddr const *skaddr)
+{
+	(void)skaddr;
+	int stime = time((time_t*)NULL);
+	for (; difftime(time((time_t*)NULL), stime) <= TIMEOUT;) {
+		/* TODO 看下能不能只接受某类包，包过滤 */
+		recvfrom(skfd, recvbuff, BUFF_LEN, 0, NULL, NULL);
+		/* eap包且是request */
+		if (recvethii->type == htons(ETHII_8021X)
+				&& mac_equal(recvethii->dst_mac, client_mac)
+				&& recveapol->type == EAPOL_PACKET
+				&& recveap->code == EAP_CODE_REQ
+				&& recveap->type == EAP_TYPE_IDEN) {
+				return 0;
+		}
+	}
+	return -1;
+}
+/*
+ * 过滤得到eap-request-md5clg包
+ * @return: 0: 成功获取
+ *          -1: 超时
+ *          -2: 服务器中止登录，用户名不存在
+ */
+static int filte_req_md5clg(int skfd, struct sockaddr const *skaddr)
+{
+	(void)skaddr;
+	int stime = time((time_t*)NULL);
+	for (; difftime(time((time_t*)NULL), stime) <= TIMEOUT;) {
+		recvfrom(skfd, recvbuff, BUFF_LEN, 0, NULL, NULL);
+		/* 是request且是eap-request-md5clg */
+		if (recvethii->type == htons(ETHII_8021X)
+				&& mac_equal(recvethii->dst_mac, client_mac)
+				&& recveapol->type == EAPOL_PACKET ) {
+			if (recveap->code == EAP_CODE_REQ
+					&& recveap->type == EAP_TYPE_MD5) {
+#ifdef DEBUG
+				_M("id: %d\n", sendeap->id);
+				_M("md5: ");
+				int i;
+				for (i = 0; i < recveapbody->md5size; ++i)
+					_M("%.2x", recveapbody->md5value[i]);
+				_M("\n");
+				_M("ex-md5: ");
+				for (i = 0; i < ntohs(recveap->len) - recveapbody->md5size - 2; ++i)
+					_M("%.2x", recveapbody->md5exdata[i]);
+				_M("\n");
+#endif
+				return 0;
+			} else if (recveap->id == sendeap->id
+					&& recveap->code == EAP_CODE_FAIL) {
+				_D("id: %d fail.\n", sendeap->id);
+				return -2;
+			}
+		}
+	}
+	return -1;
+}
+/*
+ * 过滤得到登录成功包
+ * @return: 0: 成功获取
+ *          -1: 超时
+ *          -2: 服务器中止登录，密码错误吧
+ */
+static int filte_success(int skfd, struct sockaddr const *skaddr)
+{
+	(void)skaddr;
+	int stime = time((time_t*)NULL);
+	for (; difftime(time((time_t*)NULL), stime) <= TIMEOUT;) {
+		recvfrom(skfd, recvbuff, BUFF_LEN, 0, NULL, NULL);
+		if (recvethii->type == htons(ETHII_8021X)
+				&& mac_equal(recvethii->dst_mac, client_mac)
+				&& recveapol->type == EAPOL_PACKET ) {
+			if (recveap->id == sendeap->id
+					&& recveap->code == EAP_CODE_SUCS) {
+				_D("id: %d login success.\n", sendeap->id);
+				return 0;
+			} else if (recveap->id == sendeap->id
+					&& recveap->code == EAP_CODE_FAIL) {
+				_D("id: %d fail.\n", sendeap->id);
+				return -2;
+			}
+		}
+	}
+	return -1;
+}
+/*
+ * 广播发送eapol-start
+ */
+static int eapol_start(int skfd, struct sockaddr const *skaddr)
+{
+	/* 这里采用eap标记的组播mac地址，也许采用广播也可以吧 */
+	uchar broadcast_mac[ETH_ALEN] = {
+//		0x01, 0x80, 0xc2, 0x00, 0x00, 0x03,
+		0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+	};
+	memcpy(sendethii->dst_mac, broadcast_mac, ETH_ALEN);
+	memcpy(sendethii->src_mac, client_mac, ETH_ALEN);
+	sendethii->type = htons(ETHII_8021X);
+	sendeapol->ver = EAPOL_VER;
+	sendeapol->type = EAPOL_START;
+	sendeapol->len = 0x0;
+	sendto(skfd, sendbuff, ETH_ALEN*2+6, 0, skaddr, sizeof(struct sockaddr_ll));
+	return 0;
+}
+/* 退出登录 */
+static int eapol_logoff(int skfd, struct sockaddr const *skaddr)
+{
+	uchar broadcast_mac[ETH_ALEN] = {
+//		0x01, 0x80, 0xc2, 0x00, 0x00, 0x03,
+		0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+	};
+	memcpy(sendethii->dst_mac, broadcast_mac, ETH_ALEN);
+	memcpy(sendethii->src_mac, client_mac, ETH_ALEN);
+	sendethii->type = htons(ETHII_8021X);
+	sendeapol->ver = EAPOL_VER;
+	sendeapol->type = EAPOL_LOGOFF;
+	sendeapol->len = 0x0;
+	sendeap->id = EAPOL_LOGOFF_ID;
+	sendto(skfd, sendbuff, ETH_ALEN*2+6, 0, skaddr, sizeof(struct sockaddr_ll));
+	return 0;
+}
+/* 回应request-identity */
+static int eap_res_identity(int skfd, struct sockaddr const *skaddr)
+{
+	memcpy(sendethii->dst_mac, recvethii->src_mac, ETH_ALEN);
+	sendeapol->type = EAPOL_PACKET;
+	sendeapol->len = htons(sizeof(eap_t)+sizeof(eapbody_t));
+	sendeap->code = EAP_CODE_RES;
+	sendeap->id = recveap->id;
+	sendeap->len = htons(sizeof(eapbody_t));
+	sendeap->type = EAP_TYPE_IDEN;
+	strncpy((char*)sendeapbody->identity, _uname, UNAME_LEN);
+	sendto(skfd, sendbuff, ETH_ALEN*2+6+5+sizeof(eapbody_t),
+			0, skaddr, sizeof(struct sockaddr_ll));
+	return 0;
+}
+/* 回应md5clg */
+static int eap_md5_clg(int skfd, struct sockaddr const *skaddr)
+{
+	uchar md5buff[BUFF_LEN];
+	sendeap->id = recveap->id;
+	sendeap->len = htons(sizeof(eapbody_t));
+	sendeap->type = EAP_TYPE_MD5;
+	sendeapbody->md5size = recveapbody->md5size;
+	memcpy(md5buff, &sendeap->id, 1);
+	memcpy(md5buff+1, _pwd, pwdlen);
+	memcpy(md5buff+1+pwdlen, recveapbody->md5value, recveapbody->md5size);
+	MD5(md5buff, 1+pwdlen+recveapbody->md5size, sendeapbody->md5value);
+	memcpy((char*)sendeapbody->md5exdata, _uname, strlen(_uname));
+	sendto(skfd, sendbuff, ETH_ALEN*2+6+5+sizeof(eapbody_t),
+			0, skaddr, sizeof(struct sockaddr_ll));
+	return 0;
+}
+
+/*
+ * 保持在线
+ * eap心跳包
+ * 某些eap实现需要心跳或多次认证
+ * 目前有些服务器会有如下特征
+ * 每一分钟，服务端发送一个request-identity包来判断是否在线
+ */
+static int eap_keep_alive(int skfd, struct sockaddr const *skaddr)
+{
+	int status;
+	time_t stime, etime;
+	/* EAP_KPALV_TIMEOUT时间内已经不再有心跳包，我们认为服务器不再需要心跳包了 */
+	//for (; difftime(time((time_t*)NULL), stime) <= EAP_KPALV_TIMEOUT; ) {
+	stime = time((time_t*)NULL);
+	for (;;) {
+		status = filte_req_identity(skfd, skaddr);
+		//_D("%s: [EAP:KPALV] get status: %d\n", format_time(), status);
+		if (0 == status) {
+			etime = time((time_t*)NULL);
+			_D("dtime: %fs\n", difftime(etime, stime));
+			if (difftime(etime, stime) <= 10) {
+				stime = time((time_t*)NULL);
+				continue;
+			}
+			stime = time((time_t*)NULL);
+#if 0
+#ifdef DEBUG
+			_D("[KPALV] get eap request identity:\n");
+			_D("dst<-src: %2X:%2X:%2X:%2X:%2X:%2X <- %2X:%2X:%2X:%2X:%2X:%2X\n",
+					recvethii->dst_mac[0], recvethii->dst_mac[1], recvethii->dst_mac[2],
+					recvethii->dst_mac[3], recvethii->dst_mac[4], recvethii->dst_mac[5],
+					recvethii->src_mac[0], recvethii->src_mac[1], recvethii->src_mac[2],
+					recvethii->src_mac[3], recvethii->src_mac[4], recvethii->src_mac[5]);
+			_D("ethII.type: 0x%4x\n", ntohs(recvethii->type));
+			_D("recveapol.type: %s\n", recveapol->type==EAPOL_PACKET?"EAPOL_PACKET":"UNKNOWN");
+			_D("recveapol.len: %d\n", ntohs(recveapol->len));
+			_D("recveap.code: %s\n", recveap->code==EAP_CODE_REQ?"EAP_CODE_REQ":"UNKNOWN");
+			_D("recveap.id: %d\n", recveap->id);
+			_D("recveap.type: %s\n", recveap->type==EAP_TYPE_IDEN?"EAP_TYPE_IDEN":"UNKNOWN");
+#endif
+#endif
+			_M("%s: [EAP:KPALV] get a request-identity\n", format_time());
+			eap_res_identity(skfd, skaddr);
+#if 0
+#ifdef DEBUG
+			_D("[EAP:KPALV] send eap response identity:\n");
+			_D("dst<-src: %2X:%2X:%2X:%2X:%2X:%2X <- %2X:%2X:%2X:%2X:%2X:%2X\n",
+					sendethii->dst_mac[0], sendethii->dst_mac[1], sendethii->dst_mac[2],
+					sendethii->dst_mac[3], sendethii->dst_mac[4], sendethii->dst_mac[5],
+					sendethii->src_mac[0], sendethii->src_mac[1], sendethii->src_mac[2],
+					sendethii->src_mac[3], sendethii->src_mac[4], sendethii->src_mac[5]);
+			_D("ethII.type: 0x%4x\n", ntohs(sendethii->type));
+			_D("sendeapol.type: %s\n", sendeapol->type==EAPOL_PACKET?"EAPOL_PACKET":"UNKNOWN");
+			_D("sendeapol.len: %d\n", ntohs(sendeapol->len));
+			_D("sendeap.code: %s\n", sendeap->code==EAP_CODE_RES?"EAP_CODE_RES":"UNKNOWN");
+			_D("sendeap.id: %d\n", sendeap->id);
+			_D("sendeap.type: %s\n", sendeap->type==EAP_TYPE_IDEN?"EAP_TYPE_IDEN":"UNKNOWN");
+			_D("sendeapbody.identity: %s\n", sendeapbody->identity);
+#endif
+#endif
+		}
+		status = -1;
+	}
+	return 0;
+}
+/*
+ * 后台心跳进程
+ * @return: 0, 正常运行
+ * 			-1, 运行失败
+ */
+static int eap_daemon(int skfd, struct sockaddr const *skaddr)
+{
+	/* 如果存在原来的keep alive进程，就干掉他 */
+#define PID_FILE	"/tmp/cwnu-drcom-eap.pid"
+	FILE *kpalvfd = fopen(PID_FILE, "r+");
+	if (NULL == kpalvfd) {
+		_M("[EAP:KPALV] No process pidfile. %s: %s\n", PID_FILE, strerror(errno));
+		kpalvfd = fopen(PID_FILE, "w+"); /* 不存在，创建 */
+		if (NULL == kpalvfd) {
+			_M("[EAP:KPALV] Detect pid file eror(%s)! quit!\n", strerror(errno));
+			return -1;
+		}
+	}
+	pid_t oldpid;
+
+	fseek(kpalvfd, 0L, SEEK_SET);
+	if ((1 == fscanf(kpalvfd, "%d", (int*)&oldpid)) && (oldpid != (pid_t)-1)) {
+		_D("oldkpalv pid: %d\n", oldpid);
+		kill(oldpid, SIGKILL);
+	}
+	setsid();
+	if (0 != chdir("/"))
+		_M("[EAP:KPALV:WARN] %s\n", strerror(errno));
+	umask(0);
+	/* 在/tmp下写入自己(keep alive)pid */
+	pid_t curpid = getpid();
+	_D("kpalv curpid: %d\n", curpid);
+	/*
+	 * if (0 != ftruncate(fileno(kpalvfd), 0))
+	 * 这个写法有时不能正常截断文件，截断后前面有\0？
+	 */
+	if (NULL == (kpalvfd = freopen(PID_FILE, "w+", kpalvfd)))
+		_M("[EAP:KPALV:WARN] truncat pidfile '%s': %s\n", PID_FILE, strerror(errno));
+	fprintf(kpalvfd, "%d", curpid);
+	fflush(kpalvfd);
+	if (0 == eap_keep_alive(skfd, skaddr)) {
+		_M("%s: [EAP:KPALV] Server maybe not need keep alive paket.\n", format_time());
+		_M("%s: [EAP:KPALV] Now, keep alive process quit!\n", format_time());
+	}
+	if (NULL == (kpalvfd = freopen(PID_FILE, "w+", kpalvfd)))
+		_M("[EAP:KPALV:WARN] truncat pidfile '%s': %s\n", PID_FILE, strerror(errno));
+	fprintf(kpalvfd, "-1");	/* 写入-1表示已经离开 */
+	fflush(kpalvfd);
+	fclose(kpalvfd);
+
+	return 0;
+}
+
+/*
+ * eap认证
+ * uname: 用户名
+ * pwd: 密码
+ * @return: 0: 成功
+ *          1: 用户不存在
+ *          2: 密码错误
+ *          3: 其他超时
+ *          4: 服务器拒绝请求登录
+ *          -1: 没有找到合适网络接口
+ *          -2: 没有找到服务器
+ */
+int eaplogin(char const *uname, char const *pwd)
+{
+	int i;
+	int state;
+	int skfd;
+	struct sockaddr_ll ll;
+
+	_M("Use user '%s' to login...\n", uname);
+	_M("[EAP:0] Initilize interface...\n");
+	strncpy(_uname, uname, UNAME_LEN);
+	strncpy(_pwd, pwd, PWD_LEN);
+	pwdlen = strlen(_pwd);
+	if (0 != eapol_init(&skfd, (struct sockaddr*)&ll))
+		return -1;
+	/* 无论如何先请求一下下线 */
+	eapol_logoff(skfd, (struct sockaddr*)&ll);
+	/* eap-start */
+	_M("[EAP:1] Send eap-start...\n");
+	for (i = 0; i < TRY_TIMES; ++i) {
+		eapol_start(skfd, (struct sockaddr*)&ll);
+		if (0 == filte_req_identity(skfd, (struct sockaddr*)&ll))
+			break;
+		_M(" [EAP:1] %dth Try send eap-start...\n", i+1);
+	}
+	if (i >= TRY_TIMES) goto _timeout;
+
+	/* response-identity */
+	_M("[EAP:2] Send response-identity...\n");
+	for (i = 0; i < TRY_TIMES; ++i) {
+		eap_res_identity(skfd, (struct sockaddr*)&ll);
+		state = filte_req_md5clg(skfd, (struct sockaddr*)&ll);
+		if (0 == state) break;
+		else if (-2 == state) goto _no_uname;
+		_M(" [EAP:2] %dth Try send response-identity...\n", i+1);
+	}
+	if (i >= TRY_TIMES) goto _timeout;
+
+	/* response-md5clg */
+	_M("[EAP:3] Send response-md5clg...\n");
+	for (i = 0; i < TRY_TIMES; ++i) {
+		eap_md5_clg(skfd, (struct sockaddr*)&ll);
+		state = filte_success(skfd, (struct sockaddr*)&ll);
+		if (0 == state) {
+            _M("[EAP:4] Login success.\n");
+            break;	/* 登录成功 */
+        }
+		else if (-2 == state) goto _pwd_err;
+		_M(" [EAP:3] %dth Try send response-md5clg...\n", i+1);
+	}
+	if (i >= TRY_TIMES) goto _timeout;
+
+	/* 登录成功，生成心跳进程 */
+	switch (fork()) {
+	case 0:
+		if (0 != eap_daemon(skfd, (struct sockaddr*)&ll)) {
+			_M("[EAP:ERROR] Create daemon process to keep alive error!\n");
+			close(skfd);
+			exit(1);
+		}
+		exit(0);
+		break;
+	case -1:
+		_M("[EAP:WARN] Cant create daemon, maybe `OFFLINE` after soon.\n");
+	}
+	close(skfd);
+	return 0;
+
+_timeout:
+	_M("[EAP:ERROR] Not server in range.\n");
+	close(skfd);
+	return -2;
+_no_uname:
+	_M("[EAP:ERROR] No this user(%s).\n", uname);
+	close(skfd);
+	return 1;
+_pwd_err:
+	_M("[EAP:ERROR] The server refuse to login. Password error.\n");
+	close(skfd);
+	return 4;
+}
+
+int eaplogoff(void)
+{
+	int skfd;
+	struct sockaddr_ll ll;
+	int state;
+	int i;
+
+	_M("[EAP:0] Initilize interface...\n");
+	if (0 != eapol_init(&skfd, (struct sockaddr*)&ll))
+		return -1;
+	_M("[EAP:1] Requset logoff...\n");
+	for (i = 0; i < TRY_TIMES; ++i) {
+		eapol_logoff(skfd, (struct sockaddr*)&ll);
+		state = filte_success(skfd, (struct sockaddr*)&ll);
+		if (-2 == state) {
+			_M("[EAP:2] Logoff!\n");
+			return 0;
+		}
+		_M(" [EAP:1] %dth Try Requset logoff...\n", i+1);
+	}
+	_M("[EAP:ERROR] Not server in range. or You were logoff.\n");
+	return -1;
+}
+
+int eaprefresh(char const *uname, char const *pwd)
+{
+	return eaplogin(uname, pwd);
+}
+
+/* 设置ifname */
+void setifname(char const *_ifname)
+{
+	strncpy(ifname, _ifname, IFNAMSIZ);
+}

--- a/eapol.h
+++ b/eapol.h
@@ -1,0 +1,120 @@
+#ifndef EAPOL_H__
+#define EAPOL_H__
+
+#include "common.h"
+
+#define IDEN_LEN    UNAME_LEN
+
+#define TRY_TIMES   (3)
+/* 每次请求超过TIMEOUT秒，就重新请求一次 */
+#define TIMEOUT     (3)
+/* eap 在EAP_KPALV_TIMEOUT秒内没有回应，认为不需要心跳 */
+#define EAP_KPALV_TIMEOUT   (420)   /* 7分钟 */
+
+/* ethii层取0x888e表示上层是8021.x */
+#define ETHII_8021X (0x888e)
+
+#define EAPOL_VER       (0x01)
+#define EAPOL_PACKET    (0x00)
+#define EAPOL_START     (0x01)
+#define EAPOL_LOGOFF    (0x02)
+/* 貌似请求下线的id都是这个 */
+#define EAPOL_LOGOFF_ID (255)
+
+#define EAP_CODE_REQ    (0x01)
+#define EAP_CODE_RES    (0x02)
+#define EAP_CODE_SUCS   (0x03)
+#define EAP_CODE_FAIL   (0x04)
+#define EAP_TYPE_IDEN   (0x01)
+#define EAP_TYPE_MD5    (0x04)
+
+
+#pragma pack(1)
+/* ethii 帧 */
+/* 其实这个和struct ether_header是一样的结构 */
+typedef struct {
+    uchar dst_mac[ETH_ALEN];
+    uchar src_mac[ETH_ALEN];
+    uint16 type;        /* 取值0x888e，表明是8021.x */
+}ethII_t;
+/* eapol 帧 */
+typedef struct {
+    uchar ver;          /* 取值0x01 */
+    /*
+     * 0x00: eapol-packet
+     * 0x01: eapol-start
+     * 0x02: eapol-logoff
+     */
+    uchar type;
+    uint16 len;
+}eapol_t;
+/* eap报文头 */
+typedef struct {
+    /*
+     * 0x01: request
+     * 0x02: response
+     * 0x03: success
+     * 0x04: failure
+     */
+    uchar code;
+    uchar id;
+    uint16 len;
+    /*
+     * 0x01: identity
+     * 0x04: md5-challenge
+     */
+    uchar type;
+}eap_t;
+/* 报文体 */
+#define MD5_SIZE    16
+#define STUFF_LEN   (64)
+typedef union {
+    uchar identity[IDEN_LEN];
+    struct {
+        uchar _size;
+        uchar _md5value[MD5_SIZE];
+        uchar _exdata[STUFF_LEN];
+    }md5clg;
+}eapbody_t;
+#define md5size     md5clg._size
+#define md5value    md5clg._md5value
+#define md5exdata   md5clg._exdata
+#pragma pack()
+
+/*
+ * eap认证
+ * uname: 用户名
+ * pwd: 密码
+ * @return: 0: 成功
+ *          1: 用户不存在
+ *          2: 密码错误
+ *          3: 其他超时
+ *          4: 服务器拒绝请求登录
+ *          -1: 没有找到合适网络接口
+ *          -2: 没有找到服务器
+ */
+extern int eaplogin(char const *uname, char const *pwd);
+/*
+ * eap下线
+ */
+extern int eaplogoff(void);
+/*
+ * eap重新登录
+ */
+extern int eaprefresh(char const *uname, char const *pwd);
+/*
+ * 用来设置ifname
+ */
+extern void setifname(char const *ifname);
+#ifdef WINDOWS
+/*
+ * 由于windows下实现进程的特殊性，这里把eap_daemon导出给main_cli使用
+ * ifname: 心跳的物理接口名字
+ * @return: 0: keep alive 进程正常退出，也许并不需要心跳进程
+ *         !0: 错误原因导致keep alive 进程退出，也许是没法创建进程
+ */
+extern int eap_daemon(char const *ifname);
+#endif /* WINDOWS */
+#undef IDEN_LEN
+
+#endif

--- a/main.c
+++ b/main.c
@@ -4,6 +4,7 @@
 #include <getopt.h>
 #include "configparse.h"
 #include "auth.h"
+#include "eapol.h"
 
 #ifndef WIN32
 #include <limits.h>
@@ -26,6 +27,7 @@ int main(int argc, char *argv[]) {
             { "mode", required_argument, 0, 'm' },
             { "conf", required_argument, 0, 'c' },
             { "log", required_argument, 0, 'l' },
+            { "802.1x", required_argument, 0, '8' },
 #ifndef WIN32
             { "daemon", no_argument, 0, 'd' },
 #endif
@@ -39,7 +41,7 @@ int main(int argc, char *argv[]) {
 #ifdef WIN32
         c = getopt_long(argc, argv, "m:c:l:vh", long_options, &option_index);
 #else
-        c = getopt_long(argc, argv, "m:c:l:dvh", long_options, &option_index);
+        c = getopt_long(argc, argv, "m:c:l:8dvh", long_options, &option_index);
 #endif
         
         if (c == -1) {
@@ -87,6 +89,9 @@ int main(int argc, char *argv[]) {
             case 'v':
                 verbose_flag = 1;
                 break;
+            case '8':
+                eapol_flag = 1;
+                break;
             case 'h':
                 print_help(0);
                 break;
@@ -113,6 +118,10 @@ int main(int argc, char *argv[]) {
 #ifdef WIN32 // dirty fix with win32
             strcpy(mode, tmp);
 #endif
+            // eable 802.1x authorization
+            if (eapol_flag) {
+                eaplogin(drcom_config.username, drcom_config.password);
+            }
             dogcom(5);
         } else {
             return 1;
@@ -135,6 +144,7 @@ void print_help(int exval) {
     printf("\t--mode <dhcp/pppoe>, -m <dhcp/pppoe>  set your dogcom mode \n");
     printf("\t--conf <FILEPATH>, -c <FILEPATH>      import configuration file\n");
     printf("\t--log <LOGPATH>, -l <LOGPATH>         specify log file\n");
+    printf("\t--802.1x, -8                          enable 802.1x\n");
 #ifndef WIN32
     printf("\t--daemon, -d                          set daemon flag\n");
 #endif


### PR DESCRIPTION
# 添加802.1X认证

某些学校需要802.1x认证之后才能通过dhcp获取ip，然后才是drcom认证。
我把以前那个项目里的802.1X认证模块合并到您的项目。
在模式里添加`--802.1x`来开启认证，对于windows下的802.1x认证需要`wpcap`库来支持。
`common.*`文件是被`eapol.*`依赖，没做什么修改直接合并进来而已。