### PR TITLE
新增网卡选择

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Options:
         --conf <FILEPATH>, -c <FILEPATH>      import configuration file
         --bindip <IPADDR>, -b <IPADDR>        bind your ip address(default is 0.0.0.0)
         --log <LOGPATH>, -l <LOGPATH>         specify log file
+        --interface <IFNAME>, -i <IFNAME>     bind interface
         --802.1x, -x                          enable 802.1x
         --daemon, -d                          set daemon flag
         --eternal, -e                         set eternal flag
@@ -30,6 +31,7 @@ $ dogcom -m pppoe -c dogcom.conf -x # (PS: only on Linux build)
 $ dogcom -m pppoe -c dogcom.conf -e # eternal dogcoming (default times is 5)
 $ dogcom -m pppoe -c dogcom.conf -v
 $ dogcom -m dhcp -c dogcom.conf -b 10.2.3.12 -v
+$ dogcom -m dhcp -c dogcom.conf -i eth0.2 # (PS: only on Linux build)
 ```
 
 #### To build:

--- a/auth.c
+++ b/auth.c
@@ -12,6 +12,7 @@ typedef int socklen_t;
 #include <arpa/inet.h>
 #include <netinet/in.h>
 #include <sys/socket.h>
+#include <net/if.h>
 #endif
 
 #include "auth.h"
@@ -568,6 +569,7 @@ int dogcom(int try_times) {
 #endif
         return 1;
     }
+    
     // bind socket
     if (bind(sockfd, (struct sockaddr *)&bind_addr, sizeof(bind_addr)) < 0) {
 #ifdef WIN32
@@ -594,6 +596,21 @@ int dogcom(int try_times) {
 #endif
         return 1;
     }
+
+    // bind interface
+#ifdef linux
+    if (strlen(bind_ifr_name) > 0)
+    {
+        struct ifreq ifr;
+        memset(&ifr, 0, sizeof(ifr));
+        strcpy(ifr.ifr_name, bind_ifr_name);
+        if (setsockopt(sockfd, SOL_SOCKET, SO_BINDTODEVICE, &ifr, sizeof(ifr)) < 0)
+        {
+            perror("Failed to bind ifr");
+            return 1;
+        }
+    }
+#endif
 
     // start dogcoming
     if (strcmp(mode, "dhcp") == 0) {

--- a/configparse.c
+++ b/configparse.c
@@ -11,6 +11,7 @@ int eternal_flag = 0;
 char *log_path;
 char mode[10];
 char bind_ip[20];
+char bind_ifr_name[20];
 struct config drcom_config;
 
 static int read_d_config(char *buf, int size);

--- a/configparse.h
+++ b/configparse.h
@@ -30,6 +30,7 @@ extern int eternal_flag;
 extern char *log_path;
 extern char mode[10];
 extern char bind_ip[20];
+extern char bind_ifr_name[20];
 
 int config_parse(char *filepath);
 

--- a/main.c
+++ b/main.c
@@ -33,6 +33,7 @@ int main(int argc, char *argv[]) {
             {"bindip", required_argument, 0, 'b'},
             {"log", required_argument, 0, 'l'},
 #ifdef linux
+            {"interface", required_argument,0, 'i'}, 
             {"daemon", no_argument, 0, 'd'},
             {"802.1x", no_argument, 0, 'x'},
 #endif
@@ -44,7 +45,7 @@ int main(int argc, char *argv[]) {
         int c;
         int option_index = 0;
 #ifdef linux
-        c = getopt_long(argc, argv, "m:c:b:l:dxevh", long_options, &option_index);
+        c = getopt_long(argc, argv, "m:c:b:l:i:dxevh", long_options, &option_index);
 #else
         c = getopt_long(argc, argv, "m:c:b:l:evh", long_options, &option_index);
 #endif
@@ -98,6 +99,9 @@ int main(int argc, char *argv[]) {
 #endif
                 break;
 #ifdef linux
+            case 'i':
+                strcpy(bind_ifr_name, optarg);
+                break;
             case 'd':
                 daemon_flag = 1;
                 break;
@@ -151,6 +155,9 @@ int main(int argc, char *argv[]) {
             if (strlen(bind_ip) == 0) {
                 memcpy(bind_ip, default_bind_ip, sizeof(default_bind_ip));
             }
+            if (strlen(bind_ifr_name) == 0) {
+                memset(bind_ifr_name, 0, 20);
+            }
             dogcom(5);
         } else {
             return 1;
@@ -177,6 +184,7 @@ void print_help(int exval) {
     printf("\t--bindip <IPADDR>, -b <IPADDR>        bind your ip address(default is 0.0.0.0)\n");
     printf("\t--log <LOGPATH>, -l <LOGPATH>         specify log file\n");
 #ifdef linux
+    printf("\t--interface, -i                       bind interface\n");
     printf("\t--daemon, -d                          set daemon flag\n");
     printf("\t--802.1x, -x                          enable 802.1x\n");
 #endif


### PR DESCRIPTION
我在路由器进行多线多拨时出现了ip not match的错误，后来发现是因为不绑网卡的话udp包会根据自动路由最优选择网卡发数据包，实际ip和绑定ip不相符。
故添加了一个网卡选择选项到您的项目。
